### PR TITLE
[wip] Stop observing documents when query is already observing those

### DIFF
--- a/addon/-private/context/documents-manager.js
+++ b/addon/-private/context/documents-manager.js
@@ -77,9 +77,17 @@ export default class DocumentsManager extends Destroyable {
 
   loadedInternalDocumentForSnapshot(snapshot) {
     let ref = snapshot.ref;
-    let exists = snapshot.exists;
-    let data = snapshot.data({ serverTimestamps: 'estimate' });
-    return this.loadedInternalDocument(ref, exists, data, 'storage');
+    let path = ref.path;
+    let identity = this.context.identity.documents;
+    let internal = identity.persistedInternalDocument(path);
+    if(internal) {
+      internal.didLoad(snapshot);
+      return internal;
+    } else {
+      let exists = snapshot.exists;
+      let data = snapshot.data({ serverTimestamps: 'estimate' });
+      return this.loadedInternalDocument(ref, exists, data, 'storage');
+    }
   }
 
   localInternalDocumentDidSave(internal) {

--- a/addon/-private/context/documents-manager.js
+++ b/addon/-private/context/documents-manager.js
@@ -81,6 +81,8 @@ export default class DocumentsManager extends Destroyable {
     let identity = this.context.identity.documents;
     let internal = identity.persistedInternalDocument(path);
     if(internal) {
+      // TODO: remove internal.didLoad here
+      // doc.didLoad should call something in document manager
       internal.didLoad(snapshot);
       return internal;
     } else {

--- a/addon/-private/model/internal-document.js
+++ b/addon/-private/model/internal-document.js
@@ -119,9 +119,11 @@ export default class InternalDocument extends Internal {
     this.ignoringDataUpdates(() => this.context.dataManager.updateInternal(this.data, json, 'storage'));
   }
 
-  didLoad(exists, json) {
+  didLoad(snapshot) {
+    let exists = snapshot.exists;
     if(!(this.state.exists === undefined && !exists)) {
-      this.deserialize(json);
+      let data = snapshot.data({ serverTimestamps: 'estimate' });
+      this.deserialize(data);
     }
     this.withPropertyChanges(true, changed => this.state.onLoaded(exists, changed));
   }

--- a/addon/-private/model/internal-query.js
+++ b/addon/-private/model/internal-query.js
@@ -40,7 +40,7 @@ export default class InternalQuery extends Internal {
   }
 
   modelForSnapshot(snapshot) {
-    return this.context.loadedInternalPersistedModelForSnapshot(snapshot).model(true)
+    return this.context.loadedInternalPersistedModelForSnapshot(snapshot).model(true);
   }
 
   get query() {

--- a/addon/-private/model/internal-query.js
+++ b/addon/-private/model/internal-query.js
@@ -56,17 +56,9 @@ export default class InternalQuery extends Internal {
       onLoaded: () => this.onLoaded(),
       onUpdated: () => this.notifyContentDidChange(),
       createModel: snapshot => this.modelForSnapshot(snapshot),
-      updateModel: (model, snapshot) => this.updateModel(model, snapshot),
+      updateModel: (model, snapshot) => this.modelForSnapshot(snapshot),
       destroyModel: () => {}
     };
-  }
-
-  updateModel(model, snapshot) {
-    let path = model._internal.immutablePath;
-    if(path === snapshot.ref.path) {
-      return model;
-    }
-    return this.modelForSnapshot(snapshot);
   }
 
   _createObserver() {

--- a/addon/-private/model/observer/basic-document-observer.js
+++ b/addon/-private/model/observer/basic-document-observer.js
@@ -7,15 +7,7 @@ export default class BasicDocumentObserver extends SnapshotObserver {
   }
 
   _onSnapshot(snapshot) {
-    let exists = snapshot.exists;
-    let data = snapshot.data({ serverTimestamps: 'estimate' });
-    let metadata = snapshot.metadata;
-    let props = {
-      exists,
-      metadata,
-      data
-    };
-    return this._delegate.update(props);
+    return this._delegate.onSnapshot(snapshot);
   }
 
 }

--- a/notes/observers.md
+++ b/notes/observers.md
@@ -17,3 +17,10 @@ Context is expected to be semi-short-lived, so when query is destroyed, it shoul
 At the moment context destroys queries and only then identity -> models -> documents. It should start with identity so that document can add observer only if it is not isDestroying.
 
 Queries are recreated on dependency change. How this affects register-unregister stuff?
+
+## TODO
+
+Clean up document deserialization:
+
+* internal-document didLoad
+* documents-manager loadedInternalDocumentForSnapshot

--- a/notes/observers.md
+++ b/notes/observers.md
@@ -17,5 +17,3 @@ Context is expected to be semi-short-lived, so when query is destroyed, it shoul
 At the moment context destroys queries and only then identity -> models -> documents. It should start with identity so that document can add observer only if it is not isDestroying.
 
 Queries are recreated on dependency change. How this affects register-unregister stuff?
-
-Another option is to observe query models and separately loaded models. When query is destroyed, models are in memory, but not observed. You need to call `model.get('doc').observe();` or use `{{#observe model.doc}}..` to enable it.

--- a/notes/observers.md
+++ b/notes/observers.md
@@ -1,0 +1,21 @@
+# Snapshot Observers
+
+onSnapshot observers are added for:
+
+* persisted-reference creates BasicDocumentObserver in constructor
+* internal-query creates query type-specific observer in constructor
+
+Plan is to:
+
+* register queries as opaque sources in documents
+* unregister queries from documents on query destroy
+
+Observer has `create`, `update` and `destroy` delegate functions. those can be used to register and unregister.
+
+Context is expected to be semi-short-lived, so when query is destroyed, it should be fine to add basic document observer for doc.
+
+At the moment context destroys queries and only then identity -> models -> documents. It should start with identity so that document can add observer only if it is not isDestroying.
+
+Queries are recreated on dependency change. How this affects register-unregister stuff?
+
+Another option is to observe query models and separately loaded models. When query is destroyed, models are in memory, but not observed. You need to call `model.get('doc').observe();` or use `{{#observe model.doc}}..` to enable it.


### PR DESCRIPTION
Right now all documents are observed by using `ref.onSnapshot` along with `query.onSnapshot`. This means if query is returning 1000 documents, there is 1 query observer and 1000 ref observers. No good.